### PR TITLE
bump swift-dom to 0.5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/kelvin13/swift-grammar", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/kelvin13/swift-highlight", .upToNextMinor(from: "0.1.4")),
         .package(url: "https://github.com/kelvin13/swift-resource", .upToNextMinor(from: "0.3.2")),
-        .package(url: "https://github.com/kelvin13/swift-dom", .upToNextMinor(from: "0.5.1")),
+        .package(url: "https://github.com/kelvin13/swift-dom", .upToNextMinor(from: "0.5.2")),
         
         .package(url: "https://github.com/apple/swift-markdown.git",    revision: "swift-DEVELOPMENT-SNAPSHOT-2022-08-18-a"),
         .package(url: "https://github.com/apple/swift-syntax.git",      revision: "swift-DEVELOPMENT-SNAPSHOT-2022-08-18-a"),


### PR DESCRIPTION
`swift-dom` v0.5.1 has a segfault, so we need to bump the requirement to v0.5.2